### PR TITLE
Interrupt Mongo Load during Stop

### DIFF
--- a/native/in_memory_collection.go
+++ b/native/in_memory_collection.go
@@ -37,7 +37,7 @@ func LoadIntoMemory(ctx context.Context, uuidCollection UUIDCollection, collecti
 	for {
 		if ctx.Err() != nil {
 			log.WithError(ctx.Err()).Warn("Interrupting cursor load due to cycle stop.")
-			return it, ctx.Err()
+			return it, nil
 		}
 
 		finished, uuid, err := uuidCollection.Next()

--- a/native/in_memory_collection_test.go
+++ b/native/in_memory_collection_test.go
@@ -1,10 +1,14 @@
 package native
 
 import (
+	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestInMemoryIterator(t *testing.T) {
@@ -50,7 +54,7 @@ func TestLoadIntoMemory(t *testing.T) {
 	uuidCollection.On("Next").Return(nil)
 	uuidCollection.On("Length").Return(3)
 
-	it, err := LoadIntoMemory(uuidCollection, "collection", 0, noopBlacklist)
+	it, err := LoadIntoMemory(context.Background(), uuidCollection, "collection", 0, noopBlacklist)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, it.Length())
 }
@@ -61,7 +65,7 @@ func TestLoadIntoMemoryWithSkip(t *testing.T) {
 	uuidCollection.On("Next").Return(nil)
 	uuidCollection.On("Length").Return(3)
 
-	it, err := LoadIntoMemory(uuidCollection, "collection", 1, noopBlacklist)
+	it, err := LoadIntoMemory(context.Background(), uuidCollection, "collection", 1, noopBlacklist)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, it.Length())
 
@@ -77,7 +81,7 @@ func TestLoadIntoMemoryIgnoresBlanks(t *testing.T) {
 	uuidCollection.On("Next").Return(nil)
 	uuidCollection.On("Length").Return(3)
 
-	it, err := LoadIntoMemory(uuidCollection, "collection", 1, noopBlacklist)
+	it, err := LoadIntoMemory(context.Background(), uuidCollection, "collection", 1, noopBlacklist)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, it.Length())
 
@@ -93,7 +97,7 @@ func TestLoadIntoMemoryBlacklisted(t *testing.T) {
 	uuidCollection.On("Next").Return(nil)
 	uuidCollection.On("Length").Return(3)
 
-	it, err := LoadIntoMemory(uuidCollection, "collection", 0, func(uuid string) (bool, error) {
+	it, err := LoadIntoMemory(context.Background(), uuidCollection, "collection", 0, func(uuid string) (bool, error) {
 		if uuid == "1" {
 			return true, nil
 		}
@@ -109,13 +113,42 @@ func TestLoadIntoMemoryBlacklisted(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestLoadIntoMemoryWithContextInterrupt(t *testing.T) {
+	uuidCollection := &MockUUIDCollection{uuids: []string{"1", "2", "3"}}
+	uuidCollection.On("Close").Return(nil)
+	uuidCollection.On("Next").Return(nil).Run(func(arg1 mock.Arguments) {
+		time.Sleep(time.Millisecond * 500)
+	})
+	uuidCollection.On("Length").Return(3)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	completed := false
+
+	go func() {
+		defer wg.Done()
+		_, err := LoadIntoMemory(ctx, uuidCollection, "collection", 0, noopBlacklist)
+		assert.Error(t, err)
+		assert.Equal(t, "context canceled", err.Error())
+
+		completed = true
+	}()
+
+	cancel()
+	wg.Wait()
+	assert.True(t, completed)
+}
+
 func TestLoadIntoMemoryErrors(t *testing.T) {
 	uuidCollection := &MockUUIDCollection{uuids: []string{"1", "2", "3"}}
 	uuidCollection.On("Close").Return(nil)
 	uuidCollection.On("Next").Return(errors.New("oh dear"))
 	uuidCollection.On("Length").Return(3)
 
-	_, err := LoadIntoMemory(uuidCollection, "collection", 0, noopBlacklist)
+	_, err := LoadIntoMemory(context.Background(), uuidCollection, "collection", 0, noopBlacklist)
 	assert.Error(t, err)
 }
 
@@ -125,7 +158,7 @@ func TestLoadIntoMemoryEmptyCollection(t *testing.T) {
 	uuidCollection.On("Next").Return(nil)
 	uuidCollection.On("Length").Return(0)
 
-	it, err := LoadIntoMemory(uuidCollection, "collection", 0, noopBlacklist)
+	it, err := LoadIntoMemory(context.Background(), uuidCollection, "collection", 0, noopBlacklist)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, it.Length())
 }

--- a/native/in_memory_collection_test.go
+++ b/native/in_memory_collection_test.go
@@ -131,8 +131,7 @@ func TestLoadIntoMemoryWithContextInterrupt(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		_, err := LoadIntoMemory(ctx, uuidCollection, "collection", 0, noopBlacklist)
-		assert.Error(t, err)
-		assert.Equal(t, "context canceled", err.Error())
+		assert.NoError(t, err)
 
 		completed = true
 	}()

--- a/native/native_uuid_collection.go
+++ b/native/native_uuid_collection.go
@@ -1,6 +1,7 @@
 package native
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -67,7 +68,7 @@ func computeBatchsize(interval time.Duration) (int, error) {
 	return int(size - 1), nil
 }
 
-func NewNativeUUIDCollection(mongo DB, collection string, skip int, blist blacklist.IsBlacklisted) (UUIDCollection, error) {
+func NewNativeUUIDCollection(ctx context.Context, mongo DB, collection string, skip int, blist blacklist.IsBlacklisted) (UUIDCollection, error) {
 	tx, err := mongo.Open()
 	if err != nil {
 		return nil, err
@@ -80,7 +81,7 @@ func NewNativeUUIDCollection(mongo DB, collection string, skip int, blist blackl
 
 	cursor := &NativeUUIDCollection{collection: collection, iter: iter, length: length}
 
-	inMemory, err := LoadIntoMemory(cursor, collection, skip, blist)
+	inMemory, err := LoadIntoMemory(ctx, cursor, collection, skip, blist)
 	return inMemory, err
 }
 

--- a/native/native_uuid_collection_test.go
+++ b/native/native_uuid_collection_test.go
@@ -1,6 +1,7 @@
 package native
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -74,7 +75,7 @@ func TestNewNativeUUIDCollection(t *testing.T) {
 	mockDb.On("Open").Return(mockTx, nil)
 	mockTx.On("FindUUIDs", testCollection, 0, 100).Return(iter, 11234, nil)
 
-	actual, err := NewNativeUUIDCollection(mockDb, testCollection, 0, noopBlacklist)
+	actual, err := NewNativeUUIDCollection(context.Background(), mockDb, testCollection, 0, noopBlacklist)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, actual.Length())
 
@@ -89,7 +90,7 @@ func TestNewNativeUUIDCollectionOpenFails(t *testing.T) {
 	testCollection := "testing-123"
 	mockDb.On("Open").Return(mockTx, errors.New("fail"))
 
-	_, err := NewNativeUUIDCollection(mockDb, testCollection, 0, noopBlacklist)
+	_, err := NewNativeUUIDCollection(context.Background(), mockDb, testCollection, 0, noopBlacklist)
 	assert.Error(t, err)
 
 	mockDb.AssertExpectations(t)
@@ -108,7 +109,7 @@ func TestNewNativeUUIDCollectionFindFails(t *testing.T) {
 	mockDb.On("Open").Return(mockTx, nil)
 	mockTx.On("FindUUIDs", testCollection, 0, 100).Return(iter, 11234, errors.New("fail"))
 
-	_, err := NewNativeUUIDCollection(mockDb, testCollection, 0, noopBlacklist)
+	_, err := NewNativeUUIDCollection(context.Background(), mockDb, testCollection, 0, noopBlacklist)
 	assert.Error(t, err)
 
 	mockDb.AssertExpectations(t)
@@ -188,7 +189,7 @@ func TestNativeUUIDCollection(t *testing.T) {
 
 	t.Log(testUUID)
 
-	uuidCollection, err := NewNativeUUIDCollection(db, "methode", 0, noopBlacklist)
+	uuidCollection, err := NewNativeUUIDCollection(context.Background(), db, "methode", 0, noopBlacklist)
 	assert.NoError(t, err)
 
 	found := false

--- a/scheduler/throttled_whole_collection_cycle.go
+++ b/scheduler/throttled_whole_collection_cycle.go
@@ -41,7 +41,8 @@ func (l *ThrottledWholeCollectionCycle) start(ctx context.Context) {
 }
 
 func (l *ThrottledWholeCollectionCycle) publishCollectionCycle(ctx context.Context, skip int) (int, bool) {
-	uuidCollection, err := native.NewNativeUUIDCollection(l.db, l.DBCollection, skip, l.blacklist)
+	uuidCollection, err := native.NewNativeUUIDCollection(ctx, l.db, l.DBCollection, skip, l.blacklist)
+
 	if err != nil {
 		log.WithField("id", l.CycleID).WithField("name", l.CycleName).WithField("collection", l.DBCollection).WithError(err).Warn("Failed to consume UUIDs from the Native UUID Collection.")
 		l.UpdateState(stoppedState, unhealthyState)


### PR DESCRIPTION
Currently, the load from mongo will not stop until it completes - however, if the load is not interrupted during cycle stops, multiple loads can occur at the same time.