### PR TITLE
Validate params on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/husobee/vestigo"
 	cli "gopkg.in/urfave/cli.v1"
 	"errors"
-	"strings"
 	"fmt"
 )
 
@@ -259,31 +258,8 @@ func validateMandatoryParams(ctx *cli.Context) error {
 		return errors.New("Lagcheck URL is missing")
 	}
 
-	if err := checkMongoUrls(ctx.String("mongo-db"), ctx.Int("mongo-node-count")); err != nil {
+	if err := native.CheckMongoUrls(ctx.String("mongo-db"), ctx.Int("mongo-node-count")); err != nil {
 		return fmt.Errorf("Provided MongoDB URLs are invalid: %s", err.Error())
-	}
-
-	return nil
-}
-
-func checkMongoUrls(providedMongoUrls string, expectedMongoNodeCount int) error {
-	if providedMongoUrls == "" {
-		return errors.New("MongoDB urls are missing")
-	}
-
-	mongoUrls := strings.Split(providedMongoUrls, ",")
-	actualMongoNodeCount := len(mongoUrls)
-	if actualMongoNodeCount != expectedMongoNodeCount {
-		return fmt.Errorf("The provided list of MongoDB URLs should have %d instances, but it has %d instead. Provided MongoDB URLs are: %s", expectedMongoNodeCount, actualMongoNodeCount, providedMongoUrls)
-	}
-
-	for _, mongoUrl := range mongoUrls {
-		urlComponents := strings.Split(mongoUrl, ":")
-		noOfUrlComponents := len(urlComponents)
-
-		if noOfUrlComponents != 2 || urlComponents[0] == "" || urlComponents[1] == "" {
-			return fmt.Errorf("One of the MongoDB URLs is invalid: %s. It should have host and port.", mongoUrl)
-		}
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -259,7 +259,7 @@ func validateMandatoryParams(ctx *cli.Context) error {
 		return errors.New("Lagcheck URL is missing")
 	}
 
-	if err := checkMongoUrls(ctx.String("mongo-db"), ctx.String("mongo-node-count")); err != nil {
+	if err := checkMongoUrls(ctx.String("mongo-db"), ctx.Int("mongo-node-count")); err != nil {
 		return fmt.Errorf("Provided MongoDB URLs are invalid: %s", err.Error())
 	}
 

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/husobee/vestigo"
 	cli "gopkg.in/urfave/cli.v1"
-	"errors"
 	"fmt"
 )
 
@@ -150,7 +149,7 @@ func main() {
 		log.Info("Starting the Publish Carousel.")
 
 		if err := native.CheckMongoURLs(ctx.String("mongo-db"), ctx.Int("mongo-node-count")); err != nil {
-			panic(fmt.Sprintf("Provided MongoDB URLs are invalid: %s",err))
+			panic(fmt.Sprintf("Provided MongoDB URLs are invalid: %s", err))
 		}
 
 		s3rw := s3.NewReadWriter(ctx.String("aws-region"), ctx.String("s3-bucket"))

--- a/native/mongo.go
+++ b/native/mongo.go
@@ -133,10 +133,10 @@ func CheckMongoUrls(providedMongoUrls string, expectedMongoNodeCount int) error 
 	for _, mongoUrl := range mongoUrls {
 		host, port, err := net.SplitHostPort(mongoUrl);
 		if err != nil {
-			return fmt.Errorf("One of the MongoDB URLs is invalid. Error is: %s", err.Error())
+			return fmt.Errorf("Cannot split MongoDB URL: %s into host and port. Error is: %s",mongoUrl, err.Error())
 		}
 		if host == "" || port == "" {
-			return fmt.Errorf("One of the MongoDB URLs is invalid: %s. It should have host and port.", mongoUrl)
+			return fmt.Errorf("One of the MongoDB URLs is incomplete: %s. It should have host and port.", mongoUrl)
 		}
 	}
 

--- a/native/mongo.go
+++ b/native/mongo.go
@@ -119,7 +119,7 @@ func (tx *MongoTX) ReadNativeContent(collectionID string, uuid string) (*Content
 	return result, nil
 }
 
-func CheckMongoUrls(providedMongoUrls string, expectedMongoNodeCount int) error {
+func CheckMongoURLs(providedMongoUrls string, expectedMongoNodeCount int) error {
 	if providedMongoUrls == "" {
 		return errors.New("MongoDB urls are missing")
 	}
@@ -127,7 +127,7 @@ func CheckMongoUrls(providedMongoUrls string, expectedMongoNodeCount int) error 
 	mongoUrls := strings.Split(providedMongoUrls, ",")
 	actualMongoNodeCount := len(mongoUrls)
 	if actualMongoNodeCount < expectedMongoNodeCount {
-		return fmt.Errorf("The provided list of MongoDB URLs should have %d instances, but it has %d instead. Provided MongoDB URLs are: %s", expectedMongoNodeCount, actualMongoNodeCount, providedMongoUrls)
+		return fmt.Errorf("The list of MongoDB URLs should have %d instances, but it has %d instead. Provided MongoDB URLs are: %s", expectedMongoNodeCount, actualMongoNodeCount, providedMongoUrls)
 	}
 
 	for _, mongoUrl := range mongoUrls {

--- a/native/mongo_test.go
+++ b/native/mongo_test.go
@@ -230,28 +230,28 @@ func TestDBCloses(t *testing.T) {
 	})
 }
 
-func TestCheckMongoUrlsValidUrls(t *testing.T) {
-	err := CheckMongoUrls("valid-url.com:1234", 1)
+func TestCheckMongoURLsValidUrls(t *testing.T) {
+	err := CheckMongoURLs("valid-url.com:1234", 1)
 	assert.Nil(t, err)
 }
 
-func TestCheckMongoUrlsMissingUrls(t *testing.T) {
-	err := CheckMongoUrls("", 1)
+func TestCheckMongoURLsMissingUrls(t *testing.T) {
+	err := CheckMongoURLs("", 1)
 	assert.NotNil(t, err)
 }
 
-func TestCheckMongoUrlsSmallerNumberOfUrls(t *testing.T) {
-	err := CheckMongoUrls("valid-url.com:1234", 2)
+func TestCheckMongoURLsSmallerNumberOfUrls(t *testing.T) {
+	err := CheckMongoURLs("valid-url.com:1234", 2)
 	assert.NotNil(t, err)
 }
 
-func TestCheckMongoUrlsMissingPort(t *testing.T) {
-	err := CheckMongoUrls("valid-url.com:", 1)
+func TestCheckMongoURLsMissingPort(t *testing.T) {
+	err := CheckMongoURLs("valid-url.com:", 1)
 	assert.NotNil(t, err)
 }
 
 
-func TestCheckMongoUrlsMissingHost(t *testing.T) {
-	err := CheckMongoUrls(":1234", 1)
+func TestCheckMongoURLsMissingHost(t *testing.T) {
+	err := CheckMongoURLs(":1234", 1)
 	assert.NotNil(t, err)
 }

--- a/native/mongo_test.go
+++ b/native/mongo_test.go
@@ -245,11 +245,15 @@ func TestCheckMongoURLsSmallerNumberOfUrls(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestCheckMongoURLsGreaterNumberOfUrls(t *testing.T) {
+	err := CheckMongoURLs("valid-url.com:1234,second-valid-url.com:1234", 1)
+	assert.NoError(t, err)
+}
+
 func TestCheckMongoURLsMissingPort(t *testing.T) {
 	err := CheckMongoURLs("valid-url.com:", 1)
 	assert.Error(t, err)
 }
-
 
 func TestCheckMongoURLsMissingHost(t *testing.T) {
 	err := CheckMongoURLs(":1234", 1)

--- a/native/mongo_test.go
+++ b/native/mongo_test.go
@@ -108,9 +108,9 @@ func TestFindUUIDsDateSort(t *testing.T) {
 	testUUID3 := uuid.NewUUID().String()
 	testUUIDs := []string{testUUID1, testUUID2, testUUID3}
 
-	insertTestContent(t, db, testUUID2, time.Now().Add(-10*time.Second))
+	insertTestContent(t, db, testUUID2, time.Now().Add(-10 * time.Second))
 	insertTestContent(t, db, testUUID1, time.Now())
-	insertTestContent(t, db, testUUID3, time.Now().Add(-20*time.Second))
+	insertTestContent(t, db, testUUID3, time.Now().Add(-20 * time.Second))
 
 	iter, count, err := tx.FindUUIDs("methode", 0, 10)
 	assert.NoError(t, err)
@@ -142,8 +142,8 @@ func TestFindByTimeWindow(t *testing.T) {
 	testUUID2 := uuid.NewUUID().String()
 	t.Log("Test uuids to use", testUUID, testUUID2)
 
-	insertTestContent(t, db, testUUID, time.Now().Add(time.Second*-1))
-	insertTestContent(t, db, testUUID2, time.Now().Add(time.Minute*-2))
+	insertTestContent(t, db, testUUID, time.Now().Add(time.Second * -1))
+	insertTestContent(t, db, testUUID2, time.Now().Add(time.Minute * -2))
 
 	end := time.Now()
 	start := end.Add(time.Minute * -1)
@@ -189,7 +189,7 @@ func TestReadNativeContent(t *testing.T) {
 	assert.NotNil(t, content)
 
 	assert.Equal(t, testUUID, content.Body["uuid"])
-	assert.Equal(t, "tid_"+testUUID, content.Body["publishReference"])
+	assert.Equal(t, "tid_" + testUUID, content.Body["publishReference"])
 	cleanupTestContent(t, db, testUUID)
 }
 
@@ -228,4 +228,30 @@ func TestDBCloses(t *testing.T) {
 	assert.Panics(t, func() {
 		db.(*MongoDB).session.Ping()
 	})
+}
+
+func TestCheckMongoUrlsValidUrls(t *testing.T) {
+	err := CheckMongoUrls("valid-url.com:1234", 1)
+	assert.Nil(t, err)
+}
+
+func TestCheckMongoUrlsMissingUrls(t *testing.T) {
+	err := CheckMongoUrls("", 1)
+	assert.NotNil(t, err)
+}
+
+func TestCheckMongoUrlsSmallerNumberOfUrls(t *testing.T) {
+	err := CheckMongoUrls("valid-url.com:1234", 2)
+	assert.NotNil(t, err)
+}
+
+func TestCheckMongoUrlsMissingPort(t *testing.T) {
+	err := CheckMongoUrls("valid-url.com:", 1)
+	assert.NotNil(t, err)
+}
+
+
+func TestCheckMongoUrlsMissingHost(t *testing.T) {
+	err := CheckMongoUrls(":1234", 1)
+	assert.NotNil(t, err)
 }

--- a/native/mongo_test.go
+++ b/native/mongo_test.go
@@ -232,26 +232,26 @@ func TestDBCloses(t *testing.T) {
 
 func TestCheckMongoURLsValidUrls(t *testing.T) {
 	err := CheckMongoURLs("valid-url.com:1234", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCheckMongoURLsMissingUrls(t *testing.T) {
 	err := CheckMongoURLs("", 1)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestCheckMongoURLsSmallerNumberOfUrls(t *testing.T) {
 	err := CheckMongoURLs("valid-url.com:1234", 2)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestCheckMongoURLsMissingPort(t *testing.T) {
 	err := CheckMongoURLs("valid-url.com:", 1)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 
 func TestCheckMongoURLsMissingHost(t *testing.T) {
 	err := CheckMongoURLs(":1234", 1)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/native/mongo_test.go
+++ b/native/mongo_test.go
@@ -231,7 +231,7 @@ func TestDBCloses(t *testing.T) {
 }
 
 func TestCheckMongoURLsValidUrls(t *testing.T) {
-	err := CheckMongoURLs("valid-url.com:1234", 1)
+	err := CheckMongoURLs("valid-url.com:1234,second-valid-url.com:1234,third-valid-url.com:1234", 3)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
The problem:

- The sidekick of a service sets the following entry in etcd: ft/config//host <HOST_VALUE> on strartup and deletes it when the service is stopped. In the case of publish-carousel, the service reads this etcd entry on start up and if it is not set, it defaults to localhost. Consequently, when starting nativerw in one of the COCO clusters and mongo instances are stopped, the ft/config/mongodb-x/host etcd entry is not set and the path to mongos will default to localhost instead of the ones from cluster.

Note: this issue is only reproducible in COCO clusters, not in Kubernetes