### PR TITLE
Faster republish of methode articles, throttle set to 3s

### DIFF
--- a/cycles.yml
+++ b/cycles.yml
@@ -4,7 +4,7 @@ cycles:
       origin: methode-web-pub
       collection: methode
       coolDown: 5m
-      throttle: 1s
+      throttle: 3s
    -  name: wordpress-whole-archive
       type: ThrottledWholeCollection
       origin: wordpress

--- a/cycles.yml
+++ b/cycles.yml
@@ -4,11 +4,13 @@ cycles:
       origin: methode-web-pub
       collection: methode
       coolDown: 5m
+      throttle: 1s
    -  name: wordpress-whole-archive
       type: ThrottledWholeCollection
       origin: wordpress
       collection: wordpress
       coolDown: 5m
+      throttle: 6s
 
   # -  name: methode-one-hour
   #    type: ScalingWindow

--- a/helm/publish-carousel/values.yaml
+++ b/helm/publish-carousel/values.yaml
@@ -22,7 +22,7 @@ env:
   lagcheck:
     url: http://kafka-lagcheck:8080
   toggle: "true"
-  throttle: "6s"
+  throttle: "2s"
 resources:
   requests:
     memory: 128Mi

--- a/helm/publish-carousel/values.yaml
+++ b/helm/publish-carousel/values.yaml
@@ -22,7 +22,7 @@ env:
   lagcheck:
     url: http://kafka-lagcheck:8080
   toggle: "true"
-  throttle: "2s"
+  throttle: "6s"
 resources:
   requests:
     memory: 128Mi


### PR DESCRIPTION
I've set methode collection throttle to `3s` and also specified 6s for wordpress (that was the default anyways so no real change).

Explanation:
The default throttle was set to 6s for both methode and wordpress collections (they are republished in parallel).
The largest collection is methode, which has ~1.4 million articles.
The wordpress collection has ~200000 articles.
With the default throttle (of 6s), all methode articles will be republished in ~97 days, and all wordpress ones in ~14 days.

With this change, to 3s throttle for methode collection, all methode articles will be republished in ~48 days.
