### PR TITLE
Stop carousel for staging

### DIFF
--- a/helm/publish-carousel/app-configs/publish-carousel_publishing_staging_eu.yaml
+++ b/helm/publish-carousel/app-configs/publish-carousel_publishing_staging_eu.yaml
@@ -1,0 +1,4 @@
+# Values used for the deployed application.
+replicaCount: 0
+service:
+  name: publish-carousel


### PR DESCRIPTION
# Description

## What

Stop publish carousel on staging

## Why

Publishes coming from the carousel are suppose to propagate from prod to staging so no need to run a separate carousel on staging.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
